### PR TITLE
[fix] [style] improve nyt sorting for institutional authors

### DIFF
--- a/style/sciencespo.bbx
+++ b/style/sciencespo.bbx
@@ -4,6 +4,34 @@
 \RequireBibliographyStyle{authoryear}
 \input{sciencespo-common.def}
 
+% Sorting: keep name/year/title order but fall back to institutional fields
+% before title for entries without personal authors (e.g. many @online entries).
+\DeclareSortingTemplate{nyt}{%
+  \sort{%
+    \field{presort}}
+  \sort[final]{%
+    \field{sortkey}}
+  \sort{%
+    \field{sortname}%
+    \field{author}%
+    \field{editor}%
+    \field{translator}%
+    \field{shortauthor}%
+    \field{shorteditor}%
+    \field{shortinstitution}%
+    \field{institution}%
+    \field{organization}%
+    \field{publisher}}
+  \sort{%
+    \field{sorttitle}%
+    \field{title}}
+  \sort{%
+    \field{sortyear}%
+    \field{year}}
+  \sort{%
+    \field{volume}%
+    \literal{0}}}
+
 % --- GESTION DU NOMBRE D'AUTEURS (et al.) ---
 \AtBeginDocument{%
     \setcounter{maxnames}{3}

--- a/style/sciencespo.bbx
+++ b/style/sciencespo.bbx
@@ -23,11 +23,11 @@
     \field{organization}%
     \field{publisher}}
   \sort{%
-    \field{sorttitle}%
-    \field{title}}
-  \sort{%
     \field{sortyear}%
     \field{year}}
+  \sort{%
+    \field{sorttitle}%
+    \field{title}}
   \sort{%
     \field{volume}%
     \literal{0}}}


### PR DESCRIPTION
Redefine the `nyt` sorting template in `sciencespo.bbx` to keep the existing name/year/title logic while adding institutional fallback fields (`shortinstitution`, `institution`, `organization`, `publisher`) before title sorting.

This ensures entries without personal authors (notably many `@online` items) are sorted more consistently and predictably.

## Summary by Sourcery

Affiner le modèle de tri de la bibliographie afin d’améliorer l’ordre nom/année/titre pour les entrées sans auteurs personnels, en intégrant des champs institutionnels comme solutions de repli avant le tri basé sur le titre.

Bug Fixes:
- Corriger l’ordre incoherent de la bibliographie pour les entrées dépourvues d’auteurs personnels, en particulier de nombreux éléments `@online`, en veillant à ce qu’elles utilisent les données institutionnelles au lieu de passer directement au tri par titre.

Enhancements:
- Redéfinir le modèle de tri `nyt` pour préserver l’ordre nom/année/titre tout en ajoutant des champs institutionnels comme solutions de repli lorsqu’aucun auteur personnel n’est présent.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the bibliography sorting template to improve name/year/title ordering for entries without personal authors by incorporating institutional fields as fallbacks before title-based sorting.

Bug Fixes:
- Fix inconsistent bibliography ordering for entries lacking personal authors, particularly many @online items, by ensuring they use institutional data instead of defaulting directly to title sorting.

Enhancements:
- Redefine the 'nyt' sorting template to preserve name/year/title order while adding institutional fields as fallbacks when no personal author is present.

</details>

Corrections de bugs :
- Corriger le tri incohérent des entrées de bibliographie, en particulier des éléments `@online` dépourvus d’auteur·rice personnel·le, en introduisant des valeurs de repli institutionnelles avant le tri par titre.

Améliorations :
- Redéfinir le modèle de tri « nyt » pour préserver l’ordre nom/année/titre tout en ajoutant des champs institutionnels comme valeurs de repli lorsqu’aucun auteur·rice personnel·le n’est présent·e.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Affiner le modèle de tri de la bibliographie afin d’améliorer l’ordre nom/année/titre pour les entrées sans auteurs personnels, en intégrant des champs institutionnels comme solutions de repli avant le tri basé sur le titre.

Bug Fixes:
- Corriger l’ordre incoherent de la bibliographie pour les entrées dépourvues d’auteurs personnels, en particulier de nombreux éléments `@online`, en veillant à ce qu’elles utilisent les données institutionnelles au lieu de passer directement au tri par titre.

Enhancements:
- Redéfinir le modèle de tri `nyt` pour préserver l’ordre nom/année/titre tout en ajoutant des champs institutionnels comme solutions de repli lorsqu’aucun auteur personnel n’est présent.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the bibliography sorting template to improve name/year/title ordering for entries without personal authors by incorporating institutional fields as fallbacks before title-based sorting.

Bug Fixes:
- Fix inconsistent bibliography ordering for entries lacking personal authors, particularly many @online items, by ensuring they use institutional data instead of defaulting directly to title sorting.

Enhancements:
- Redefine the 'nyt' sorting template to preserve name/year/title order while adding institutional fields as fallbacks when no personal author is present.

</details>

</details>