### PR TITLE
[fix][datamodel] add online publication date part fields

### DIFF
--- a/style/biblatex-dm.cfg
+++ b/style/biblatex-dm.cfg
@@ -21,5 +21,8 @@
 \DeclareDatamodelFields[type=field,datatype=literal]{platform}
 \DeclareDatamodelFields[type=field,datatype=literal]{duration}
 \DeclareDatamodelFields[type=field,datatype=date]{pubdate}
+\DeclareDatamodelFields[type=field,datatype=literal]{pubyear}
+\DeclareDatamodelFields[type=field,datatype=literal]{pubmonth}
+\DeclareDatamodelFields[type=field,datatype=literal]{pubday}
 \DeclareDatamodelFields[type=field,datatype=date]{updatedate}
-\DeclareDatamodelEntryfields[online]{platform,duration,pubdate,updatedate}
+\DeclareDatamodelEntryfields[online]{institution,journaltitle,platform,duration,pubdate,pubyear,pubmonth,pubday,updatedate}


### PR DESCRIPTION
Declare `pubyear`, `pubmonth`, and `pubday` as literal datamodel fields and register them for `online` entries, alongside `institution` and `journaltitle`. This allows partial or component-based publication date metadata to be stored explicitly when `pubdate` alone is not sufficient.

## Summary by Sourcery

Ajouter la prise en charge du stockage des composants de la date de publication des entrées en ligne en tant que champs distincts dans le datamodel.

Nouvelles fonctionnalités :
- Introduire des champs littéraux dans le datamodel pour l’année, le mois et le jour de publication.
- Enregistrer, dans le datamodel, les champs `institution`, `journaltitle` et les composants de la date de publication pour les entrées en ligne.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for storing online entry publication date components as separate datamodel fields.

New Features:
- Introduce literal datamodel fields for publication year, month, and day.
- Register institution, journaltitle, and publication date component fields for online entries in the datamodel.

</details>